### PR TITLE
Mark model update methods as internal

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -43,6 +43,7 @@
 		/**
 		 * Updates the Category's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw Category data from the server.
 		 * @return void
 		 */

--- a/src/Models/Channel.php
+++ b/src/Models/Channel.php
@@ -46,6 +46,7 @@
 		/**
 		 * Updates the channel's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw channel data from the server.
 		 * @return void
 		 */

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -47,6 +47,7 @@
 		/**
 		 * Updates the Message's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw Message data.
 		 * @return void
 		 */

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -44,6 +44,7 @@
 		/**
 		 * Updates the Role's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw Role data from the server.
 		 * @return void
 		 */

--- a/src/Models/Server.php
+++ b/src/Models/Server.php
@@ -43,6 +43,7 @@
 		/**
 		 * Updates the Server's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw Server data.
 		 * @return void
 		 */

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -47,6 +47,7 @@
 		/**
 		 * Updates the user's information dynamically.
 		 *
+		 * @internal This method is for internal framework use only. Do not call this directly.
 		 * @param array $raw The raw user data from the server.
 		 * @return void
 		 */


### PR DESCRIPTION
Add an @internal PHPDoc tag to the dynamic update methods in model classes (Category, Channel, Message, Role, Server, User) to indicate these methods are for internal framework use only and should not be called directly. This is a documentation-only change to clarify intended usage and help prevent accidental external invocation.