### PR TITLE
docs: Add missing docblocks, examples, and @throws annotations across…

### DIFF
--- a/src/Builders/MessageBuilder.php
+++ b/src/Builders/MessageBuilder.php
@@ -174,6 +174,12 @@
 		 * matching the wire format expected by the `messages.send` RPC.
 		 *
 		 * @return string The fully constructed HTML string ready for dispatch.
+		 *
+		 * @example
+		 * ```php
+		 * $builder = \Sharkord\Builders\MessageBuilder::create()->setContent('Hello!');
+		 * echo $builder->buildHtml(); // "<p>Hello!</p>"
+		 * ```
 		 */
 		public function buildHtml(): string {
 
@@ -194,6 +200,12 @@
 		 * Returns the message body text.
 		 *
 		 * @return string
+		 *
+		 * @example
+		 * ```php
+		 * $builder = \Sharkord\Builders\MessageBuilder::create()->setContent('Hello!');
+		 * echo $builder->getContent(); // "Hello!"
+		 * ```
 		 */
 		public function getContent(): string {
 
@@ -205,6 +217,15 @@
 		 * Returns the list of queued files.
 		 *
 		 * @return array<int, array{path: string, mime: string|null}>
+		 *
+		 * @example
+		 * ```php
+		 * $builder = \Sharkord\Builders\MessageBuilder::create()
+		 *     ->addFile('/tmp/a.png')
+		 *     ->addFile('/tmp/b.pdf', 'application/pdf');
+		 *
+		 * var_dump($builder->getPendingFiles());
+		 * ```
 		 */
 		public function getPendingFiles(): array {
 

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -20,6 +20,13 @@
 		 * This name is used to invoke the command (e.g., "ping" for "!ping").
 		 *
 		 * @return string The command name.
+		 *
+		 * @example
+		 * ```php
+		 * public function getName(): string {
+		 *     return 'ping';
+		 * }
+		 * ```
 		 */
 		public function getName(): string;
 
@@ -27,6 +34,13 @@
 		 * Retrieves a brief description of what the command does.
 		 *
 		 * @return string The command description.
+		 *
+		 * @example
+		 * ```php
+		 * public function getDescription(): string {
+		 *     return 'Replies with Pong!';
+		 * }
+		 * ```
 		 */
 		public function getDescription(): string;
 		
@@ -34,6 +48,13 @@
 		 * A regex pattern match that will trigger the command
 		 *
 		 * @return string The command patttern.
+		 *
+		 * @example
+		 * ```php
+		 * public function getPattern(): string {
+		 *     return '/^ping$/i';
+		 * }
+		 * ```
 		 */
 		public function getPattern(): string;
 
@@ -45,6 +66,13 @@
 		 * @param string   $args    The arguments passed with the command.
 		 * @param array    $matches Regex capture groups from the command pattern.
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * public function handle(Sharkord $sharkord, Message $message, string $args, array $matches): void {
+		 *     $message->reply('Pong!');
+		 * }
+		 * ```
 		 */
 		public function handle(Sharkord $sharkord, Message $message, string $args, array $matches): void;
 

--- a/src/Commands/CommandRouter.php
+++ b/src/Commands/CommandRouter.php
@@ -24,7 +24,7 @@
 		/**
 		 * CommandRouter constructor.
 		 *
-		 * @param LoggerInterface $logger The PSR-3 logger instance.
+		 * @param Sharkord $sharkord The main bot instance.
 		 */
 		public function __construct(
 			private Sharkord $sharkord
@@ -35,6 +35,11 @@
 		 *
 		 * @param CommandInterface $command The command object to register.
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->commands->register(new PingCommand());
+		 * ```
 		 */
 		public function register(CommandInterface $command): void {
 			
@@ -49,6 +54,11 @@
 		 * @param string $directory The absolute path to the directory containing command classes.
 		 * @param string $namespace (Optional) The namespace used in the command files. Default is empty (global).
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->commands->loadFromDirectory(__DIR__ . '/Commands', 'App\\Commands');
+		 * ```
 		 */
 		public function loadFromDirectory(string $directory, string $namespace = ''): void {
 			
@@ -94,6 +104,14 @@
 		 * @param Message	$message	The received message object.
 		 * @param array		$matches	The original regex matches
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * // Typically called automatically by the framework:
+		 * if (preg_match('/^!(\w+)\s*(.*)/s', $message->content, $matches)) {
+		 *     $sharkord->commands->handle($message, $matches);
+		 * }
+		 * ```
 		 */
 		public function handle(Message $message, array $matches): void {
 
@@ -121,6 +139,13 @@
 		 * Retrieves all registered commands. Useful for generating "Help" menus.
 		 *
 		 * @return array<string, CommandInterface>
+		 *
+		 * @example
+		 * ```php
+		 * foreach ($sharkord->commands->getCommands() as $name => $command) {
+		 *     echo "!{$name} — {$command->getDescription()}\n";
+		 * }
+		 * ```
 		 */
 		public function getCommands(): array {
 			return $this->commands;

--- a/src/Internal/Guard.php
+++ b/src/Internal/Guard.php
@@ -33,6 +33,11 @@
 		 *
 		 * @return void
 		 * @throws \RuntimeException If the bot entity is not set.
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->guard->requireBot();
+		 * ```
 		 */
 		public function requireBot(): void {
 
@@ -48,6 +53,11 @@
 		 * @param Permission $permission The permission to require.
 		 * @return void
 		 * @throws \RuntimeException If the bot entity is not set or lacks the permission.
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->guard->requirePermission(\Sharkord\Permission::MANAGE_CHANNELS);
+		 * ```
 		 */
 		public function requirePermission(Permission $permission): void {
 
@@ -71,6 +81,14 @@
 		 * @param Permission      $permission      The fallback permission to require if not the owner.
 		 * @return void
 		 * @throws \RuntimeException If the bot entity is not set, is not the owner, and lacks the permission.
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->guard->requireOwnershipOrPermission(
+		 *     $message->author?->id,
+		 *     \Sharkord\Permission::MANAGE_MESSAGES,
+		 * );
+		 * ```
 		 */
 		public function requireOwnershipOrPermission(int|string|null $resourceOwnerId, Permission $permission): void {
 
@@ -95,6 +113,11 @@
 		 * @param User $user The user to check.
 		 * @return void
 		 * @throws \RuntimeException If the user is the server owner.
+		 *
+		 * @example
+		 * ```php
+		 * $sharkord->guard->requireNotOwner($user);
+		 * ```
 		 */
 		public function requireNotOwner(User $user): void {
 

--- a/src/Internal/LoggerFactory.php
+++ b/src/Internal/LoggerFactory.php
@@ -26,6 +26,12 @@
 		 * @param string $logLevel The minimum log level name (e.g. 'Notice', 'Debug').
 		 * @return LoggerInterface
 		 * @throws \InvalidArgumentException If the log level name is invalid.
+		 *
+		 * @example
+		 * ```php
+		 * $logger = \Sharkord\Internal\LoggerFactory::create('Debug');
+		 * $logger->info("Logger initialised.");
+		 * ```
 		 */
 		public static function create(string $logLevel): LoggerInterface {
 

--- a/src/Internal/PromiseUtils.php
+++ b/src/Internal/PromiseUtils.php
@@ -22,6 +22,15 @@
 		 *
 		 * @param mixed $reason The rejection reason.
 		 * @return string A human-readable representation of the rejection reason.
+		 *
+		 * @example
+		 * ```php
+		 * $promise->catch(function(mixed $reason) use ($sharkord) {
+		 *     $sharkord->logger->error(
+		 *         \Sharkord\Internal\PromiseUtils::reasonToString($reason)
+		 *     );
+		 * });
+		 * ```
 		 */
 		public static function reasonToString(mixed $reason): string {
 

--- a/src/Internal/ReconnectHandler.php
+++ b/src/Internal/ReconnectHandler.php
@@ -42,6 +42,12 @@
 		 * Resets the attempt counter after a successful connection.
 		 *
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * // Called automatically after a successful connection.
+		 * $reconnectHandler->reset();
+		 * ```
 		 */
 		public function reset(): void {
 
@@ -56,6 +62,12 @@
 		 * Backs off at 2^attempt seconds (2s, 4s, 8s...) capped at 60 seconds.
 		 *
 		 * @return void
+		 *
+		 * @example
+		 * ```php
+		 * // Called automatically when the gateway connection is lost.
+		 * $reconnectHandler->attempt();
+		 * ```
 		 */
 		public function attempt(): void {
 

--- a/src/Models/Channel.php
+++ b/src/Models/Channel.php
@@ -133,6 +133,13 @@
 		 * For longer operations, use sendTypingWhile() instead.
 		 *
 		 * @return PromiseInterface Resolves with true on success, rejects on failure.
+		 *
+		 * @example
+		 * ```php
+		 * $channel->sendTyping()->then(function() {
+		 *     echo "Typing indicator sent.\n";
+		 * });
+		 * ```
 		 */
 		public function sendTyping(): PromiseInterface {
 
@@ -162,6 +169,16 @@
 		 *
 		 * @param PromiseInterface $promise The operation to show a typing indicator for.
 		 * @return PromiseInterface Resolves or rejects with the same value as the given Promise.
+		 *
+		 * @example
+		 * ```php
+		 * // Show typing while fetching data from an external API
+		 * $channel->sendTypingWhile(
+		 *     $httpClient->get('https://api.example.com/data')
+		 * )->then(function($response) use ($channel) {
+		 *     $channel->sendMessage("Got the data: {$response}");
+		 * });
+		 * ```
 		 */
 		public function sendTypingWhile(PromiseInterface $promise): PromiseInterface {
 
@@ -666,6 +683,11 @@
 		 * Returns all the attributes as a plain array. Useful for debugging.
 		 *
 		 * @return array
+		 *
+		 * @example
+		 * ```php
+		 * var_dump($channel->toArray());
+		 * ```
 		 */
 		public function toArray(): array {
 

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -47,6 +47,10 @@
 		
 		/**
 		 * Factory method to create a Message from raw API data.
+		 *
+		 * @param array    $raw      The raw message data from the server.
+		 * @param Sharkord $sharkord Reference to the main bot instance.
+		 * @return self
 		 */
 		public static function fromArray(array $raw, Sharkord $sharkord): self {
 			return new self($sharkord, $raw);
@@ -112,6 +116,16 @@
 		 *
 		 * @param string  $emoji   The emoji character(s) to use for the reaction.
 		 * @return PromiseInterface Resolves on success, rejects on failure.
+		 *
+		 * @throws \RuntimeException If the bot lacks REACT_TO_MESSAGES.
+		 * @throws \InvalidArgumentException If the emoji is invalid.
+		 *
+		 * @example
+		 * ```php
+		 * $message->react('👍')->then(function() {
+		 *     echo "Reacted!\n";
+		 * });
+		 * ```
 		 */
 		public function react(string $emoji): PromiseInterface {
 
@@ -149,6 +163,15 @@
 		 *
 		 * @param string $newContent The new message text.
 		 * @return PromiseInterface Resolves with true when the message is edited.
+		 *
+		 * @throws \RuntimeException If the bot lacks ownership or MANAGE_MESSAGES.
+		 *
+		 * @example
+		 * ```php
+		 * $message->edit('Updated content.')->then(function() {
+		 *     echo "Message edited.\n";
+		 * });
+		 * ```
 		 */
 		public function edit(string $newContent): PromiseInterface {
 
@@ -182,6 +205,15 @@
 		 * Deletes this message.
 		 *
 		 * @return PromiseInterface Resolves with true when the message is deleted.
+		 *
+		 * @throws \RuntimeException If the bot lacks ownership or MANAGE_MESSAGES.
+		 *
+		 * @example
+		 * ```php
+		 * $message->delete()->then(function() {
+		 *     echo "Message deleted.\n";
+		 * });
+		 * ```
 		 */
 		public function delete(): PromiseInterface {
 
@@ -219,6 +251,15 @@
 		 *
 		 * @param int $timeout Seconds to wait for the onUpdate confirmation before rejecting.
 		 * @return PromiseInterface Resolves with a bool indicating the new pinned state (true = pinned, false = unpinned).
+		 *
+		 * @throws \RuntimeException If the bot lacks MANAGE_MESSAGES or the confirmation times out.
+		 *
+		 * @example
+		 * ```php
+		 * $message->togglePin()->then(function(bool $pinned) {
+		 *     echo $pinned ? "Message pinned.\n" : "Message unpinned.\n";
+		 * });
+		 * ```
 		 */
 		public function togglePin(int $timeout = 10): PromiseInterface {
 
@@ -280,6 +321,13 @@
 		 * Checks whether this message is currently pinned.
 		 *
 		 * @return bool True if the message is pinned, false otherwise.
+		 *
+		 * @example
+		 * ```php
+		 * if ($message->isPinned()) {
+		 *     echo "This message is pinned.\n";
+		 * }
+		 * ```
 		 */
 		public function isPinned(): bool {
 			return (bool)($this->attributes['pinned'] ?? false);
@@ -333,6 +381,13 @@
 		 * Determines whether this message contains any user mentions.
 		 *
 		 * @return bool True if the message mentions one or more users, false otherwise.
+		 *
+		 * @example
+		 * ```php
+		 * if ($message->hasMentions()) {
+		 *     echo "Someone was mentioned!\n";
+		 * }
+		 * ```
 		 */
 		public function hasMentions(): bool {
 			

--- a/src/Models/Server.php
+++ b/src/Models/Server.php
@@ -35,6 +35,10 @@
 		
 		/**
 		 * Factory method to create a Server from raw API data.
+		 *
+		 * @param array    $raw      The raw server data from the server.
+		 * @param Sharkord $sharkord Reference to the main bot instance.
+		 * @return self
 		 */
 		public static function fromArray(array $raw, Sharkord $sharkord): self {
 			return new self($sharkord, $raw);
@@ -58,6 +62,11 @@
 		 * Returns all the attributes as an array. Perfect for debugging!
 		 *
 		 * @return array
+		 *
+		 * @example
+		 * ```php
+		 * var_dump($sharkord->servers->getFirst()?->toArray());
+		 * ```
 		 */
 		public function toArray(): array {
 			

--- a/src/Models/ServerSettings.php
+++ b/src/Models/ServerSettings.php
@@ -138,7 +138,7 @@
 		 *         name: 'The Boyz',
 		 *         allowNewUsers: false,
 		 *         directMessagesEnabled: true,
-		 *         nableSearch: true,
+		 *         enableSearch: true,
 		 *     );
 		 * })->then(function () {
 		 *     echo "Settings updated!\n";

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -42,6 +42,10 @@
 		
 		/**
 		 * Factory method to create a User from raw API data.
+		 *
+		 * @param array    $raw      The raw user data from the server.
+		 * @param Sharkord $sharkord Reference to the main bot instance.
+		 * @return self
 		 */
 		public static function fromArray(array $raw, Sharkord $sharkord): self {
 			return new self($sharkord, $raw);
@@ -84,6 +88,13 @@
 		 *
 		 * @param Permission $permission The permission enum case to check.
 		 * @return bool True if any of the user's roles have the permission, false otherwise.
+		 *
+		 * @example
+		 * ```php
+		 * if ($user->hasPermission(\Sharkord\Permission::MANAGE_CHANNELS)) {
+		 *     echo "{$user->name} can manage channels.\n";
+		 * }
+		 * ```
 		 */
 		public function hasPermission(Permission $permission): bool {
 			
@@ -96,6 +107,13 @@
 		 * Checks if the user is a server owner.
 		 *
 		 * @return bool True if the user is an owner, false otherwise.
+		 *
+		 * @example
+		 * ```php
+		 * if ($user->isOwner()) {
+		 *     echo "{$user->name} is a server owner.\n";
+		 * }
+		 * ```
 		 */
 		public function isOwner(): bool {
 			
@@ -108,6 +126,13 @@
 		 *
 		 * @param int $roleId The role id to check.
 		 * @return bool True if the user has the role, false otherwise.
+		 *
+		 * @example
+		 * ```php
+		 * if ($user->hasRole(3)) {
+		 *     echo "{$user->name} has the Moderator role.\n";
+		 * }
+		 * ```
 		 */
 		public function hasRole(int $roleId): bool {
 			// Get all the Role objects for this user using the magic getter
@@ -128,6 +153,15 @@
 		 *
 		 * @param string $reason The reason for the ban.
 		 * @return PromiseInterface Resolves on success, rejects on failure.
+		 *
+		 * @throws \RuntimeException If the bot lacks MANAGE_USERS or the target is the server owner.
+		 *
+		 * @example
+		 * ```php
+		 * $user->ban('Spamming in #general')->then(function() use ($user) {
+		 *     echo "{$user->name} has been banned.\n";
+		 * });
+		 * ```
 		 */
 		public function ban(string $reason = 'No reason given.'): PromiseInterface {
 
@@ -149,6 +183,15 @@
 		 * Unbans a user from the server.
 		 *
 		 * @return PromiseInterface Resolves on success, rejects on failure.
+		 *
+		 * @throws \RuntimeException If the bot lacks MANAGE_USERS.
+		 *
+		 * @example
+		 * ```php
+		 * $user->unban()->then(function() use ($user) {
+		 *     echo "{$user->name} has been unbanned.\n";
+		 * });
+		 * ```
 		 */
 		public function unban(): PromiseInterface {
 
@@ -170,6 +213,15 @@
 		 *
 		 * @param string $reason The reason for the kick.
 		 * @return PromiseInterface Resolves on success, rejects on failure.
+		 *
+		 * @throws \RuntimeException If the bot lacks MANAGE_USERS or the target is the server owner.
+		 *
+		 * @example
+		 * ```php
+		 * $user->kick('Violating server rules')->then(function() use ($user) {
+		 *     echo "{$user->name} has been kicked.\n";
+		 * });
+		 * ```
 		 */
 		public function kick(string $reason = 'No reason given.'): PromiseInterface {
 
@@ -192,6 +244,15 @@
 		 *
 		 * @param bool  $wipe Whether to delete all associated user data (posts, files, emoji, etc.).
 		 * @return PromiseInterface Resolves on success, rejects on failure.
+		 *
+		 * @throws \RuntimeException If the bot lacks MANAGE_USERS or the target is the server owner.
+		 *
+		 * @example
+		 * ```php
+		 * $user->delete(wipe: true)->then(function() use ($user) {
+		 *     echo "{$user->name} and all their data have been removed.\n";
+		 * });
+		 * ```
 		 */
 		public function delete(bool $wipe = false): PromiseInterface {
 
@@ -263,6 +324,11 @@
 		 * Returns all the attributes as an array. Perfect for debugging!
 		 *
 		 * @return array
+		 *
+		 * @example
+		 * ```php
+		 * var_dump($user->toArray());
+		 * ```
 		 */
 		public function toArray(): array {
 			

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -4,6 +4,29 @@
 
 	namespace Sharkord;
 
+	/**
+	 * Enum Permission
+	 *
+	 * Represents the server-wide permissions that can be assigned to roles.
+	 *
+	 * @package Sharkord
+	 *
+	 * @example
+	 * ```php
+	 * // Check if the bot has a specific permission
+	 * if ($sharkord->bot->hasPermission(\Sharkord\Permission::MANAGE_MESSAGES)) {
+	 *     echo "Bot can manage messages.\n";
+	 * }
+	 *
+	 * // Grant permissions when editing a role
+	 * $sharkord->roles->get(3)?->edit(
+	 *     'Moderators',
+	 *     '#00aaff',
+	 *     \Sharkord\Permission::MANAGE_MESSAGES,
+	 *     \Sharkord\Permission::MANAGE_USERS,
+	 * );
+	 * ```
+	 */
 	enum Permission: string {
 		
 		case SEND_MESSAGES = 'SEND_MESSAGES';


### PR DESCRIPTION
… all source files (#76)

- Add class docblock to Permission enum
- Expand incomplete fromArray() docblocks on User, Message, Server
- Fix incorrect @param type on CommandRouter constructor
- Fix typo in ServerSettings update() example
- Add @example blocks to 30+ public methods
- Add @throws annotations to guarded async methods