### PR TITLE
refactor: Centralise RPC validation, fix escaping, and expand Server …

### DIFF
--- a/src/Commands/CommandRouter.php
+++ b/src/Commands/CommandRouter.php
@@ -77,7 +77,12 @@
 			}
 
 			foreach ($files as $file) {
-				
+
+				if (!is_file($file) || !is_readable($file)) {
+					$this->sharkord->logger->warning("Skipping unreadable command file: {$file}");
+					continue;
+				}
+
 				require_once $file;
 				$className = basename($file, '.php');
 				$fullClassName = $namespace ? $namespace . '\\' . $className : $className;

--- a/src/Internal/PromiseUtils.php
+++ b/src/Internal/PromiseUtils.php
@@ -42,6 +42,40 @@
 
 		}
 
+		/**
+		 * Validates that an RPC response has `type === 'data'`, indicating success.
+		 *
+		 * Centralises the repeated response-validation pattern used by every
+		 * mutation call across the framework. Throws on failure so the caller can
+		 * rely on a truthy return for the success path.
+		 *
+		 * @param array  $response The decoded RPC response array.
+		 * @param string $action   A short human-readable description of the action
+		 *                         (e.g. "edit message") used in the exception message.
+		 * @return true Always returns true on success.
+		 *
+		 * @throws \RuntimeException If the response does not indicate success.
+		 *
+		 * @example
+		 * ```php
+		 * $this->sharkord->gateway->sendRpc("mutation", [
+		 *     "input" => ["messageId" => $this->id],
+		 *     "path"  => "messages.delete",
+		 * ])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'delete message'));
+		 * ```
+		 */
+		public static function expectDataResponse(array $response, string $action): true {
+
+			if (isset($response['type']) && $response['type'] === 'data') {
+				return true;
+			}
+
+			throw new \RuntimeException(
+				"Failed to {$action}. Server responded with: " . json_encode($response)
+			);
+
+		}
+
 	}
 	
 ?>

--- a/src/Managers/CategoryManager.php
+++ b/src/Managers/CategoryManager.php
@@ -7,6 +7,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 	use Sharkord\Collections\Categories as CategoriesCollection;
 	use Sharkord\Models\Category;
 	use React\Promise\PromiseInterface;
@@ -310,17 +311,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["categoryIds" => array_values($categoryIds)],
 					"path"  => "categories.reorder",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to reorder categories. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'reorder categories'));
 
 			});
 

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -7,6 +7,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 	use React\Promise\PromiseInterface;
 
 	/**
@@ -157,17 +158,7 @@
 						"name"       => $name,
 					],
 					"path" => "categories.update",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to edit category. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'edit category'));
 
 			});
 
@@ -197,17 +188,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["categoryId" => $this->id],
 					"path"  => "categories.delete",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to delete category. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'delete category'));
 
 			});
 

--- a/src/Models/Channel.php
+++ b/src/Models/Channel.php
@@ -146,17 +146,7 @@
 			return $this->sharkord->gateway->sendRpc("mutation", [
 				"input" => ["channelId" => $this->id],
 				"path"  => "messages.signalTyping",
-			])->then(function ($response) {
-
-				if (isset($response['type']) && $response['type'] === 'data') {
-					return true;
-				}
-
-				throw new \RuntimeException(
-					"Failed to send typing indicator. Server responded with: " . json_encode($response)
-				);
-
-			});
+			])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'send typing indicator'));
 
 		}
 
@@ -228,17 +218,7 @@
 			return $this->sharkord->gateway->sendRpc("mutation", [
 				"input" => ["channelId" => $this->id],
 				"path"  => "channels.markAsRead",
-			])->then(function ($response) {
-
-				if (isset($response['type']) && $response['type'] === 'data') {
-					return true;
-				}
-
-				throw new \RuntimeException(
-					"Failed to mark channel as read. Server responded with: " . json_encode($response)
-				);
-
-			});
+			])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'mark channel as read'));
 
 		}
 
@@ -311,17 +291,7 @@
 					"files"     => $fileIds,
 				],
 				"path" => "messages.send",
-			])->then(function ($response): bool {
-
-				if (isset($response['type']) && $response['type'] === 'data') {
-					return true;
-				}
-
-				throw new \RuntimeException(
-					"Failed to send message. Server responded with: " . json_encode($response)
-				);
-
-			});
+			])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'send message'));
 
 		}
 
@@ -410,17 +380,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => $input,
 					"path"  => "channels.update",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to edit channel. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'edit channel'));
 
 			});
 
@@ -450,17 +410,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["channelId" => $this->id],
 					"path"  => "channels.delete",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to delete channel. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'delete channel'));
 
 			});
 
@@ -560,18 +510,7 @@
 						"isCreate"  => true,
 					],
 					"path" => "channels.updatePermissions",
-				])->then(function (array $response) use ($roleId) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to add role {$roleId} to channel permissions. Server responded with: "
-							. json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, "add role {$roleId} to channel permissions"));
 
 			});
 
@@ -613,18 +552,7 @@
 						"permissions" => array_map(fn(ChannelPermissionFlag $f) => $f->value, $permissions),
 					],
 					"path" => "channels.updatePermissions",
-				])->then(function (array $response) use ($roleId) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to update permissions for role {$roleId}. Server responded with: "
-							. json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, "update permissions for role {$roleId}"));
 
 			});
 
@@ -658,18 +586,7 @@
 						"channelId" => $this->id,
 					],
 					"path" => "channels.deletePermissions",
-				])->then(function (array $response) use ($roleId) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to remove role {$roleId} from channel permissions. Server responded with: "
-							. json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, "remove role {$roleId} from channel permissions"));
 
 			});
 

--- a/src/Models/DirectMessage.php
+++ b/src/Models/DirectMessage.php
@@ -5,6 +5,7 @@
 	namespace Sharkord\Models;
 
 	use Sharkord\Sharkord;
+	use Sharkord\Internal\PromiseUtils;
 	use React\Promise\PromiseInterface;
 
 	/**
@@ -89,22 +90,12 @@
 
 			return $this->sharkord->gateway->sendRpc("mutation", [
 				"input" => [
-					"content"   => "<p>" . htmlspecialchars($text) . "</p>",
+					"content"   => "<p>" . htmlspecialchars($text, ENT_QUOTES, 'UTF-8') . "</p>",
 					"channelId" => $this->channelId,
 					"files"     => [],
 				],
 				"path" => "messages.send",
-			])->then(function ($response) {
-
-				if (isset($response['type']) && $response['type'] === 'data') {
-					return true;
-				}
-
-				throw new \RuntimeException(
-					"Failed to send DM. Server responded with: " . json_encode($response)
-				);
-
-			});
+			])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'send DM'));
 
 		}
 
@@ -135,17 +126,7 @@
 			return $this->sharkord->gateway->sendRpc("mutation", [
 				"input" => ["channelId" => $this->channelId],
 				"path"  => "channels.markAsRead",
-			])->then(function ($response) {
-
-				if (isset($response['type']) && $response['type'] === 'data') {
-					return true;
-				}
-
-				throw new \RuntimeException(
-					"Failed to mark DM as read. Server responded with: " . json_encode($response)
-				);
-
-			});
+			])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'mark DM as read'));
 
 		}
 

--- a/src/Models/Invite.php
+++ b/src/Models/Invite.php
@@ -8,6 +8,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 
 	/**
 	 * Class Invite
@@ -141,14 +142,9 @@
 					"path"  => "invites.delete",
 				])->then(function (array $response) use ($inviteId): bool {
 
-					if (isset($response['type']) && $response['type'] === 'data') {
-						$this->sharkord->invites->collection()->remove($inviteId);
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to delete invite. Server responded with: " . json_encode($response)
-					);
+					PromiseUtils::expectDataResponse($response, 'delete invite');
+					$this->sharkord->invites->collection()->remove($inviteId);
+					return true;
 
 				});
 

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -7,6 +7,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 	use Sharkord\Collections\Reactions;
 	use Sharkord\Builders\MessageBuilder;
 
@@ -142,17 +143,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["messageId" => $this->id, "emoji" => $emojiText],
 					"path"  => "messages.toggleReaction"
-				])->then(function ($response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to react to message. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'react to message'));
 
 			});
 
@@ -185,17 +176,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["messageId" => $this->id, "content" => $newContent],
 					"path"  => "messages.edit"
-				])->then(function ($response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to edit message. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'edit message'));
 
 			});
 
@@ -227,17 +208,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["messageId" => $this->id],
 					"path"  => "messages.delete"
-				])->then(function ($response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to delete message. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'delete message'));
 
 			});
 
@@ -267,51 +238,59 @@
 
 				$this->sharkord->guard->requirePermission(Permission::MANAGE_MESSAGES);
 
-				return new Promise(function ($resolve, $reject) use ($timeout) {
+				return $this->sharkord->gateway->sendRpc("mutation", [
+					"input" => ["messageId" => $this->id],
+					"path"  => "messages.togglePin"
+				])->then(function (array $response) use ($timeout) {
 
-					$this->sharkord->gateway->sendRpc("mutation", [
-						"input" => ["messageId" => $this->id],
-						"path"  => "messages.togglePin"
-					])->then(function ($response) use ($resolve, $reject, $timeout) {
+					PromiseUtils::expectDataResponse($response, 'toggle pin');
 
-						if (!isset($response['type']) || $response['type'] !== 'data') {
-							$reject(new \RuntimeException(
-								"Failed to toggle pin. Server responded with: " . json_encode($response)
-							));
-							return;
-						}
-
-						$normalizedId = (string) $this->id;
-						$listener     = null;
-						$timer        = null;
-
-						$cleanup = function () use (&$listener, &$timer) {
-							$this->sharkord->removeListener('messageupdate', $listener);
-							if ($timer) {
-								$this->sharkord->loop->cancelTimer($timer);
-								$timer = null;
-							}
-						};
-
-						$listener = function (Message $updated) use ($resolve, $normalizedId, &$cleanup) {
-							if ((string) $updated->id === $normalizedId) {
-								$cleanup();
-								$resolve((bool) $updated->pinned);
-							}
-						};
-
-						$timer = $this->sharkord->loop->addTimer($timeout, function () use ($reject, $normalizedId, &$cleanup) {
-							$cleanup();
-							$reject(new \RuntimeException(
-								"togglePin timed out waiting for onUpdate confirmation for message ID {$normalizedId}."
-							));
-						});
-
-						$this->sharkord->on('messageupdate', $listener);
-
-					})->catch($reject);
+					return $this->awaitPinConfirmation($timeout);
 
 				});
+
+			});
+
+		}
+
+		/**
+		 * Waits for the server's messageupdate subscription event to confirm
+		 * the new pinned state after a togglePin mutation.
+		 *
+		 * @param int $timeout Seconds to wait before rejecting.
+		 * @return PromiseInterface Resolves with a bool indicating the new pinned state.
+		 */
+		private function awaitPinConfirmation(int $timeout): PromiseInterface {
+
+			return new Promise(function ($resolve, $reject) use ($timeout) {
+
+				$normalizedId = (string) $this->id;
+				$listener     = null;
+				$timer        = null;
+
+				$cleanup = function () use (&$listener, &$timer) {
+					$this->sharkord->removeListener('messageupdate', $listener);
+					if ($timer) {
+						$this->sharkord->loop->cancelTimer($timer);
+						$timer = null;
+					}
+				};
+
+				$listener = function (Message $updated) use ($resolve, $normalizedId, &$cleanup) {
+					if ((string) $updated->id === $normalizedId) {
+						$cleanup();
+						$resolve((bool) $updated->pinned);
+					}
+				};
+
+				$timer = $this->sharkord->loop->addTimer($timeout, function () use ($reject, $normalizedId, &$cleanup) {
+					$cleanup();
+					$reject(new \RuntimeException(
+						"togglePin timed out waiting for onUpdate confirmation for message ID {$normalizedId}."
+					));
+				});
+
+				$this->sharkord->on('messageupdate', $listener);
 
 			});
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -7,6 +7,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 	use React\Promise\PromiseInterface;
 
 	/**
@@ -114,17 +115,7 @@
 						"permissions" => array_map(fn(Permission $p) => $p->value, $permissions),
 					],
 					"path" => "roles.update",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to edit role. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'edit role'));
 
 			});
 
@@ -157,17 +148,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["roleId" => $this->id],
 					"path"  => "roles.setDefault",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to set role as default. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'set role as default'));
 
 			});
 
@@ -198,17 +179,7 @@
 				return $this->sharkord->gateway->sendRpc("mutation", [
 					"input" => ["roleId" => $this->id],
 					"path"  => "roles.delete",
-				])->then(function (array $response) {
-
-					if (isset($response['type']) && $response['type'] === 'data') {
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to delete role. Server responded with: " . json_encode($response)
-					);
-
-				});
+				])->then(fn(array $r) => PromiseUtils::expectDataResponse($r, 'delete role'));
 
 			});
 

--- a/src/Models/Server.php
+++ b/src/Models/Server.php
@@ -5,6 +5,7 @@
 	namespace Sharkord\Models;
 	
 	use Sharkord\Sharkord;
+	use React\Promise\PromiseInterface;
 
 	/**
 	 * Class Server
@@ -58,6 +59,81 @@
 			
 		}
 		
+		/**
+		 * Fetches the full administrative settings for this server.
+		 *
+		 * Convenience wrapper around {@see \Sharkord\Managers\ServerManager::getSettings()}.
+		 * Returns a {@see ServerSettings} model containing privileged fields such as
+		 * `secretToken` and `allowNewUsers` that are not included in the public settings.
+		 *
+		 * Requires the MANAGE_SETTINGS permission.
+		 *
+		 * @return PromiseInterface Resolves with a {@see ServerSettings} instance, rejects on failure.
+		 *
+		 * @example
+		 * ```php
+		 * $server->getSettings()->then(function(\Sharkord\Models\ServerSettings $settings) {
+		 *     echo "Server: {$settings->name}\n";
+		 *     echo "Allow signup: " . ($settings->allowNewUsers ? 'Yes' : 'No') . "\n";
+		 * });
+		 * ```
+		 */
+		public function getSettings(): PromiseInterface {
+
+			return $this->sharkord->servers->getSettings();
+
+		}
+
+		/**
+		 * Updates one or more server settings.
+		 *
+		 * Convenience wrapper that fetches the current {@see ServerSettings} and
+		 * delegates to {@see ServerSettings::update()}. The server will broadcast
+		 * an `onServerSettingsUpdate` event, which updates the cached Server model
+		 * automatically.
+		 *
+		 * Requires the MANAGE_SETTINGS permission.
+		 *
+		 * @param string|null $name                   New server display name.
+		 * @param string|null $description            New server description.
+		 * @param string|null $password               New server password. Pass an empty string to remove.
+		 * @param bool|null   $allowNewUsers          Whether to permit new user registrations.
+		 * @param bool|null   $directMessagesEnabled  Whether to enable direct messaging server-wide.
+		 * @param bool|null   $enablePlugins          Whether to enable server plugins.
+		 * @param bool|null   $enableSearch           Whether to enable server-wide search.
+		 * @return PromiseInterface Resolves with true on success, rejects on failure.
+		 *
+		 * @example
+		 * ```php
+		 * $server->edit(name: 'The Boyz', allowNewUsers: false)->then(function() {
+		 *     echo "Settings updated!\n";
+		 * });
+		 * ```
+		 */
+		public function edit(
+			?string $name = null,
+			?string $description = null,
+			?string $password = null,
+			?bool   $allowNewUsers = null,
+			?bool   $directMessagesEnabled = null,
+			?bool   $enablePlugins = null,
+			?bool   $enableSearch = null,
+		): PromiseInterface {
+
+			return $this->getSettings()->then(
+				fn(ServerSettings $settings) => $settings->update(
+					name: $name,
+					description: $description,
+					password: $password,
+					allowNewUsers: $allowNewUsers,
+					directMessagesEnabled: $directMessagesEnabled,
+					enablePlugins: $enablePlugins,
+					enableSearch: $enableSearch,
+				)
+			);
+
+		}
+
 		/**
 		 * Returns all the attributes as an array. Perfect for debugging!
 		 *

--- a/src/Models/ServerSettings.php
+++ b/src/Models/ServerSettings.php
@@ -9,6 +9,7 @@
 	use Sharkord\Sharkord;
 	use Sharkord\Permission;
 	use Sharkord\Internal\GuardedAsync;
+	use Sharkord\Internal\PromiseUtils;
 
 	/**
 	 * Class ServerSettings
@@ -182,14 +183,9 @@
 					"path"  => "others.updateSettings",
 				])->then(function (array $response) use ($input): bool {
 
-					if (isset($response['type']) && $response['type'] === 'data') {
-						$this->updateFromArray($response['data'] ?? $input);
-						return true;
-					}
-
-					throw new \RuntimeException(
-						"Failed to update server settings. Server responded with: " . json_encode($response)
-					);
+					PromiseUtils::expectDataResponse($response, 'update server settings');
+					$this->updateFromArray($response['data'] ?? $input);
+					return true;
 
 				});
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -135,17 +135,9 @@
 		 * ```
 		 */
 		public function hasRole(int $roleId): bool {
-			// Get all the Role objects for this user using the magic getter
-			$roles = $this->roleIds;
 
-			if ($roles && in_array($roleId, $roles, false)) {
-				
-				return true;
-				
-			}
+			return !empty($this->roleIds) && in_array($roleId, $this->roleIds, false);
 
-			// If we checked all roles and didn't find the permission, return false
-			return false;
 		}
 		
 		/**


### PR DESCRIPTION
…model (#78)

* docs: Add missing docblocks, examples, and @throws annotations across all source files (#76)

- Add class docblock to Permission enum
- Expand incomplete fromArray() docblocks on User, Message, Server
- Fix incorrect @param type on CommandRouter constructor
- Fix typo in ServerSettings update() example
- Add @example blocks to 30+ public methods
- Add @throws annotations to guarded async methods

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* refactor: Centralise RPC validation, fix escaping, and expand Server model

Extract the repeated RPC response-validation pattern (20+ identical blocks across models and managers) into PromiseUtils::expectDataResponse(), reducing boilerplate by ~80 lines while preserving identical error behaviour.

- Add PromiseUtils::expectDataResponse() for centralised mutation validation
- Fix inconsistent HTML escaping in DirectMessage::send() (missing ENT_QUOTES/UTF-8)
- Simplify User::hasRole() to a single-expression return
- Refactor Message::togglePin() to separate RPC call from event-wait logic
- Add Server::getSettings() and Server::edit() convenience methods
- Add file validation in CommandRouter::loadFromDirectory() before require_once